### PR TITLE
`BlurhashFfiImage` using `hash` as expected 

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ class BlurHashApp extends StatelessWidget {
 }
 
 /// 2. Using the `BlurhashFfiImage` ImageProvider
-final imageProvider = BlurhashFfiImage(hash: "L5H2EC=PM+yV0g-mq.wG9c010J}I");
+final imageProvider = BlurhashFfiImage("L5H2EC=PM+yV0g-mq.wG9c010J}I");
 class BlurHashApp2 extends StatelessWidget {
   const BlurHashApp2({Key? key}) : super(key: key);
 


### PR DESCRIPTION
# In this Pull-Request

- docs: `BlurhashFfiImage` without `hash` as named parameter; because the `hash` parameter is positional parameter.
- closes #3.